### PR TITLE
Einführung einer Variablen für den Kurstitel

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -29,6 +29,7 @@ theme = "hugo-theme-relearn"
   themeVariant = "bits"
 
   BITS = "BITS"
+  BITS_Titel = "BITS | Behörden-IT-Sicherheitstraining"
   Ver = "6.0.2"
   Release = "aus Herbst 2021"
 

--- a/content/020 einleitung/_index.de.md
+++ b/content/020 einleitung/_index.de.md
@@ -7,7 +7,7 @@ weight: 20
 
 ## Informationen sind wertvoll
 
-### Ziele des Behörden-IT-Sicherheitstrainings BITS
+### Ziele des  {{< param BITS_Titel >}}
 
 Informationen sind wertvoll. Sie werden immer bedeutender für {{< param Einrichtungen >}}, aber auch Privatpersonen. Heute werden Informationen größtenteils digital gespeichert und verarbeitet. Daher rückt das Thema IT-Sicherheit mehr und mehr in den Blickpunkt. Im Zentrum stehen die **Schutzziele der Informationssicherheit**.
 

--- a/content/_index.de.md
+++ b/content/_index.de.md
@@ -6,7 +6,7 @@ disableToc: true
 ---
 # Willkommen bei {{< param BITS >}}
 
-# Behörden-IT-Sicherheitstraining
+# {{< param BITS_Titel >}}
 
 {{< param BITS >}} {{< param Ver >}} {{< param Release >}} 
 


### PR DESCRIPTION
Hallo, ich schlage vor wir führen eine Variable für den Titel des Kursus ein damit dieser nicht hart verdrahted in den Texten auftaucht. Das ermöglicht eine einfachere Anpassung an unterschiedliche Behörden und Organisationen

Gruß

Hagen Bauer