### PR TITLE
Plug-In-Lösung für Text-Variablen

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -34,6 +34,8 @@ theme = "hugo-theme-relearn"
   Release = "aus Herbst 2021"
 
   BITS_Password_Length = "12"
+  # BITS_Private_EMail kann : " Demo | Custom " enthalten bei Custom ist die Datei "content/anpassungen/private-mail.md" auf die eigenen Anforderungen anzupassen
+  BITS_Private_EMails = "Demo"
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -33,6 +33,8 @@ theme = "hugo-theme-relearn"
   Ver = "6.0.2"
   Release = "aus Herbst 2021"
 
+  BITS_Password_Length = "12"
+
 [outputs]
 home = [ "HTML", "RSS", "JSON"]
 

--- a/content/030 lektion e-mail/04.Computerviren.de.md
+++ b/content/030 lektion e-mail/04.Computerviren.de.md
@@ -24,7 +24,7 @@ In einer {{< param Einrichtung >}} wird eine E-Mail normalerweise an zwei Stelle
 
 ##### Daher sollten Sie:
 
-- E-Mail-Inhalten und Dateianhängen nicht blind vertrauen,
+- E-Mail-Inhalten und Dateianhängen nicht ungeprüft vertrauen,
 - grundsätzlich keine unbekannten oder merkwürdig erscheinenden E-Mails öffnen,
 - keine Dokumente und Programme von unbekannten Absendern öffnen, ohne sich zuvor über deren Vertrauenswürdigkeit zu vergewissern, und
 

--- a/content/030 lektion e-mail/09.Dienstliche-und-private-Nutzung.de.md
+++ b/content/030 lektion e-mail/09.Dienstliche-und-private-Nutzung.de.md
@@ -6,7 +6,8 @@ weight: 90
 icon: envelope-open-text
 ---
 
-In vielen {{% param Einrichtungen %}}  ist die Nutzung der dienstlichen E-Mail-Adresse zum Versand privater E-Mails nicht erlaubt. Dieses Verbot ist rechtlich zulässig und muss von Ihnen beachtet werden. Genaueres regeln Dienstvereinbarungen oder anderen interne Vorgaben.
+{{< toggler_Private_EMail "Demo" >}}
+In vielen {{% param Einrichtungen %}} ist die Nutzung der dienstlichen E-Mail-Adresse zum Versand privater E-Mails nicht erlaubt. Dieses Verbot ist rechtlich zulässig und muss von Ihnen beachtet werden. Genaueres regeln Dienstvereinbarungen oder anderen interne Vorgaben.
 
 {{% notice note %}}
 
@@ -16,4 +17,7 @@ Ist in Ihrer {{% param Einrichtung %}} die private Nutzung der dienstlichen E-Ma
 - Wenn ja - nutzen Sie diese nur im angemessenen Umfang und versenden und empfangen Sie allenfalls kleine Dateien!
 
 {{% /notice %}}
-
+{{< /toggler_Private_EMail >}}
+{{< toggler_Private_EMail "Custom" >}}
+{{< readfile file="content/anpassungen/private-mail.md" markdown="true" >}}
+{{< /toggler_Private_EMail >}}

--- a/content/030 lektion e-mail/11.Zusammenfassung.de.md
+++ b/content/030 lektion e-mail/11.Zusammenfassung.de.md
@@ -8,7 +8,7 @@ icon: envelope-open-text
 
 ### Hier noch einmal die wichtigsten Regeln:
 
-- Vertrauen Sie niemals blind E-Mail-Inhalten und Dateianhängen.
+- Vertrauen Sie niemals ungeprüft E-Mail-Inhalten und Dateianhängen.
 - Öffnen Sie keine Dokumente und Programme Ihnen unbekannter Personen.
 - Informieren Sie bei Verdacht auf Virenbefall Ihre [Ansprechperson]({{< ref "/200 ansprechpersonen/" >}}).
 - Geben Sie fehlgeleitete Informationen nicht weiter, sondern informieren Sie die absendende Person und löschen Sie die E-Mail.

--- a/content/050 lektion passwoerter/01.Erklaerung.de.md
+++ b/content/050 lektion passwoerter/01.Erklaerung.de.md
@@ -22,6 +22,6 @@ Auch der Zugang zu einzelnen Programmen wird häufig durch Passwörter geschütz
 
 Der Name Ihres Lebenspartners oder Ihrer Lebenspartnerin, Ihr Autokennzeichen, Ihr Geburtsdatum oder Ihre Telefonnummer stellen **keine** guten Passwörter dar. Sie könnten leicht erraten oder abgeleitet werden. Auch Fremdwörter oder Wörter einer anderen Sprache sind keine gute Wahl, da diese mit automatisierten Verfahren über Wörterbuch- oder Brute-Force-Angriffe durch Erraten geknackt werden können.
 
-Ein sicheres Passwort ist mindestens acht Zeichen lang und besteht aus einer Kombination von großen und kleinen Buchstaben, Ziffern und Sonderzeichen wie z.B. Ausrufezeichen oder Fragezeichen. Außerdem sollten keine Buchstaben genutzt werden, die auf der Tastatur direkt nebeneinander liegen. Idealerweise sollte das Passwort einmalig sein.
+Ein sicheres Passwort ist mindestens {{< param BITS_Password_Length >}} Zeichen lang und besteht aus einer Kombination von großen und kleinen Buchstaben, Ziffern und Sonderzeichen wie z.B. Ausrufezeichen oder Fragezeichen. Außerdem sollten keine Buchstaben genutzt werden, die auf der Tastatur direkt nebeneinander liegen. Idealerweise sollte das Passwort einmalig sein.
 
 In den meisten {{< param Einrichtungen >}} müssen Passwörter regelmäßig geändert werden, wobei die zuletzt gewählten Passwörter nicht wiederverwendet werden dürfen.

--- a/content/050 lektion passwoerter/04.Zusammenfassung.de.md
+++ b/content/050 lektion passwoerter/04.Zusammenfassung.de.md
@@ -9,7 +9,7 @@ icon: lock-open
 ### Wir fassen die wichtigsten Passwort-Regeln zusammen:
 
 - Sichere, möglichst einmalige Passwörter verwenden
-- Mindestens acht Zeichen lang, Buchstaben und Zahlen sowie Groß- und Kleinschreibung verwenden
+- Mindestens {{< param BITS_Password_Length >}} Zeichen lang, Buchstaben und Zahlen sowie Groß- und Kleinschreibung verwenden
 - Keine Passwörter aus Wörterbüchern, keine Namen, Geburtsdaten etc.
 - Notieren Sie Ihr Passwort nirgendwo
 - Geben Sie Ihr Passwort nicht an andere Personen weiter

--- a/content/050 lektion passwoerter/90.Quiz-Passwoerter.de.md
+++ b/content/050 lektion passwoerter/90.Quiz-Passwoerter.de.md
@@ -46,16 +46,16 @@ shuffle_answers: true
 
 > Allein Buchstaben oder sinnvolle Buchstabenkombinationen und Geburtsdaten können leicht erraten werden. Daher sollen auch Zahlen etc. verwendet werden.
 
-1. [x] Ein Passwort sollte grundsätzlich mindestens acht Zeichen lang sein, Buchstaben und Zahlen sowie Groß- und Kleinschreibung enthalten, nicht im Wörterbuch stehen und keine Namen, Geburtsdaten oder Autokennzeichen enthalten.
+1. [x] Ein Passwort sollte grundsätzlich mindestens {{< param BITS_Password_Length >}} Zeichen lang sein, Buchstaben und Zahlen sowie Groß- und Kleinschreibung enthalten, nicht im Wörterbuch stehen und keine Namen, Geburtsdaten oder Autokennzeichen enthalten.
 
 	>**Richtige Antwort**
 2. [ ] Ein Passwort sollte nur aus Buchstaben bestehen.
 
-	>Wrong answer! Passwörter sollten mindestens acht Zeichen lang sein und Buchstaben und Zahlen sowie Groß- und Kleinschreibung enthalten. Sie sollten nicht im Wörterbuch stehen und keine Namen, Geburtsdaten oder Autokennzeichen sein.
+	>Wrong answer! Passwörter sollten mindestens {{< param BITS_Password_Length >}} Zeichen lang sein und Buchstaben und Zahlen sowie Groß- und Kleinschreibung enthalten. Sie sollten nicht im Wörterbuch stehen und keine Namen, Geburtsdaten oder Autokennzeichen sein.
 3. [ ] Passwörter sollten aus persönlichen Informationen wie Geburtsdatum, Name des Haustieres oder ähnlichem zusammengesetzt sein.
 
 
-	>Leider nein. Passwörter sollten mindestens acht Zeichen lang sein und Buchstaben und Zahlen sowie Groß- und Kleinschreibung enthalten. Sie sollten nicht im Wörterbuch stehen und keine Namen, Geburtsdaten oder Autokennzeichen sein.
+	>Leider nein. Passwörter sollten mindestens {{< param BITS_Password_Length >}} Zeichen lang sein und Buchstaben und Zahlen sowie Groß- und Kleinschreibung enthalten. Sie sollten nicht im Wörterbuch stehen und keine Namen, Geburtsdaten oder Autokennzeichen sein.
 
 ## Was ist beim Umgang mit Passwörtern wichtig?
 
@@ -73,7 +73,7 @@ shuffle_answers: true
 
 ## Welches Beispiel ist am schwersten zu erraten?
 
-> Passwörter, die nur aus Buchstaben bestehen, sind zu leicht zu erraten. Sie sollten außerdem mindestens acht Zeichen haben.
+> Passwörter, die nur aus Buchstaben bestehen, sind zu leicht zu erraten. Sie sollten außerdem mindestens {{< param BITS_Password_Length >}} Zeichen haben.
 
 1. [x] GHalt!123ung
 

--- a/content/anpassungen/private-mail.md
+++ b/content/anpassungen/private-mail.md
@@ -1,0 +1,3 @@
+In der Sicherheitsrichtlinie für die Nutzung von E-Mails festgelegt worden das die private Nutzung von EMail erlaubt/verboten ist.
+
+

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -1,0 +1,8 @@
+{{$file := .Get "file"}}
+{{- if eq (.Get "markdown") "true" -}}
+{{- $file  | readFile | markdownify -}}
+{{- else if  (.Get "highlight") -}}
+{{-  highlight ($file  | readFile) (.Get "highlight") "" -}}
+{{- else -}}
+{{ $file  | readFile | safeHTML }}
+{{- end -}}

--- a/layouts/shortcodes/toggler_Private_EMail.html
+++ b/layouts/shortcodes/toggler_Private_EMail.html
@@ -1,0 +1,4 @@
+{{ $value := .Get 0 }}
+{{ if eq .Site.Params.BITS_Private_EMails $value }}
+{{ .Inner }}
+{{ end }}


### PR DESCRIPTION
Um BITS auf die organisationsspezifischen Anforderungen für die Kennwortlänge anpassen zu können, schlage ich vor eine Variable einzuführen, die an den verschiedenen Stellen aufgerufen wird.   
Ich finde auch den Begriff "blind" etwas passiv und würde vorschlagen "ungeprüft" zu verwenden da hiermit gleich auch ein Aktion "prüfen" angeregt wird