### PR TITLE
BYOD: getrennte Benutzerprofile

### DIFF
--- a/content/100 lektion mobile geraete/07.Apps-und-Bring-your-own-device.de.md
+++ b/content/100 lektion mobile geraete/07.Apps-und-Bring-your-own-device.de.md
@@ -13,7 +13,8 @@ Insbesondere müssen Sie darauf achten, dass dienstliche und private Daten nicht
 - Installieren Sie nur solche Apps, die Sie benötigen und löschen Sie die anderen
 - Schränken Sie die Zugriffsberechtigungen für Ihre Kontakte, Standortangaben etc. bei Apps möglichst ein
 - Verarbeiten Sie keine dienstlichen Daten in privaten Apps
-- Auch Messenger-Apps wie z.B. WhatsApp, die Sie privat installieren und verwenden, dürfen nicht für dienstliche Zwecke genutzt werden
+- Auch Messenger-Apps wie z. B. WhatsApp, die Sie privat installieren und verwenden, dürfen nicht für dienstliche Zwecke genutzt werden
+- Nutzen Sie nach Möglichkeit verschiedene Benutzerprofile für den privaten und den dienstlichen Gebrauch
 - Löschen Sie nicht mehr benötigte WLAN-Netzwerke in den Netzwerk-Einstellungen des Geräts
 - Installieren Sie alle verfügbaren Updates für das Gerät und die Apps
 - Der Verlust eines Geräts mit vertraulichen Daten ist unverzüglich den Vorgesetzten und der [Ansprechperson]({{< ref "/200 ansprechpersonen/" >}}) zu melden


### PR DESCRIPTION
Mittlerweile bieten auch viele Smartphones die Möglichkeit, mehrere Benutzerprofile einzurichten, um eine bessere Trennung zu erreichen. Damit sollte dann beispielsweise der private Messenger nicht das dienstliche Adressbuch hochladen.